### PR TITLE
fix: update whisper-rs to 0.15.1 for macOS ARM support

### DIFF
--- a/apps/tauri/src-tauri/Cargo.lock
+++ b/apps/tauri/src-tauri/Cargo.lock
@@ -6124,18 +6124,18 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whisper-rs"
-version = "0.14.4"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2eac0a371f8ae667a5ee15ae4130553ea3004e7572544d1ce546c81ea8874b"
+checksum = "71ea5d2401f30f51d08126a2d133fee4c1955136519d7ac6cf6f5ac0a91e6bc8"
 dependencies = [
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c86f1b993f216594b1ad9a9bb00a26014fb7c512e12664a2d401c7897d2ef7d"
+checksum = "b5e2a6e06e7ac7b8f53c53a5f50bb0bc823ba69b63ecd887339f807a5598bbd2"
 dependencies = [
  "bindgen 0.71.1",
  "cfg-if",

--- a/apps/tauri/src-tauri/Cargo.toml
+++ b/apps/tauri/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ notify = "7"
 tauri-plugin-updater = "2"
 cpal = "0.15"
 rubato = "0.16"
-whisper-rs = "0.14"
+whisper-rs = "0.15"
 reqwest = { version = "0.12", features = ["stream"] }
 tokio = { version = "1", features = ["fs"] }
 futures-util = "0.3"

--- a/apps/tauri/src-tauri/src/whisper/transcriber.rs
+++ b/apps/tauri/src-tauri/src/whisper/transcriber.rs
@@ -28,16 +28,13 @@ impl WhisperTranscriber {
             .full(params, audio)
             .map_err(|e| format!("Transcription failed: {}", e))?;
 
-        let num_segments = state
-            .full_n_segments()
-            .map_err(|e| format!("Failed to get segments: {}", e))?;
+        let num_segments = state.full_n_segments();
 
         let mut text = String::new();
         for i in 0..num_segments {
-            let segment = state
-                .full_get_segment_text(i)
-                .map_err(|e| format!("Failed to get segment {i}: {e}"))?;
-            text.push_str(&segment);
+            if let Some(segment) = state.get_segment(i) {
+                text.push_str(&format!("{}", segment));
+            }
         }
         Ok(text.trim().to_string())
     }


### PR DESCRIPTION
## 🐛 Problem

The v0.4.0 release build **failed for macOS ARM** due to a compilation error in `whisper-rs-sys v0.13.1`:

```
error: always_inline function 'vmmlaq_s32' requires target feature 'i8mm'
```

The GitHub Actions macOS ARM runner doesn't support the required CPU instructions when compiling whisper.cpp with the 0.14 version.

## ✅ Solution

Update to **whisper-rs 0.15.1**, which includes:
- Better ARM64 support and compilation fixes
- Updated whisper.cpp bindings
- Simplified API (breaking changes handled)

## 📝 Changes

### Dependencies
- `whisper-rs`: 0.14.4 → **0.15.1**
- `whisper-rs-sys`: 0.13.1 → **0.14.1**

### API Adaptations
- `full_n_segments()` now returns `i32` directly (no Result)
- `full_get_segment_text()` replaced with `get_segment()` 
- Use `Display` trait implementation for text extraction: `format!("{}", segment)`

## 🧪 Test Plan

- [x] `cargo check` passes locally
- [ ] Build succeeds on macOS ARM (GitHub Actions)
- [ ] Build succeeds on macOS Intel
- [ ] Build succeeds on Linux
- [ ] Build succeeds on Windows
- [ ] Voice-to-text transcription still works correctly
- [ ] No regressions in transcription quality

## 📎 References

- Closes #3
- Blocks v0.4.0 release (fixes ARM build failure)
- CodeRabbit review comment: https://github.com/devitools/arandu/pull/2#discussion_r2838816655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated transcription library to the latest version for improved compatibility.

* **Bug Fixes**
  * Improved transcription reliability by refining error handling to better manage edge cases during text extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->