### PR TITLE
fix(ci): force armv8.5-a architecture for macOS ARM builds

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -126,6 +126,8 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          CFLAGS: ${{ matrix.target == 'aarch64-apple-darwin' && '-march=armv8.5-a' || '' }}
+          CXXFLAGS: ${{ matrix.target == 'aarch64-apple-darwin' && '-march=armv8.5-a' || '' }}
         with:
           projectPath: apps/tauri
           tagName: ${{ inputs.tag_name }}


### PR DESCRIPTION
## Summary
Fixes macOS ARM (aarch64-apple-darwin) build failures in GitHub Actions by explicitly targeting the armv8.5-a architecture during whisper.cpp compilation.

## Problem
The whisper.cpp build was failing with:
```
error: always_inline function 'vmmlaq_s32' requires target feature 'i8mm',
but would be inlined into function 'ggml_vec_dot_q4_0_q8_0' that is compiled
without support for 'i8mm'
```

This occurs because CMake auto-detects CPU features and enables i8mm intrinsics (ARMv8.6+), which aren't available on GitHub's macOS ARM runners.

## Solution
Added `CFLAGS` and `CXXFLAGS` environment variables to force `-march=armv8.5-a` architecture (which does **not** include i8mm) when building for `aarch64-apple-darwin` target.

## References
- [whisper.cpp Issue #3427](https://github.com/ggml-org/whisper.cpp/issues/3427)
- [whisper-rs Issue #117](https://github.com/tazz4843/whisper-rs/issues/117)

## Test Plan
- [x] Build succeeds on macOS x86_64 (unchanged)
- [ ] Build succeeds on macOS ARM (aarch64-apple-darwin) in GitHub Actions
- [ ] Builds succeed on Linux and Windows (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for Apple Silicon Macs to improve compilation performance and compatibility during release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->