### PR TITLE
fix(tauri): Extract IPC types to shared module for Windows compatibility

### DIFF
--- a/apps/tauri/src-tauri/src/ipc_common.rs
+++ b/apps/tauri/src-tauri/src/ipc_common.rs
@@ -1,0 +1,78 @@
+use serde::{Deserialize, Serialize};
+use tauri::{Emitter, Manager};
+
+/// IPC command structure shared between Unix socket and TCP implementations
+#[derive(Deserialize)]
+pub struct IpcCommand {
+    pub command: String,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+/// IPC response structure shared between Unix socket and TCP implementations
+#[derive(Serialize)]
+pub struct IpcResponse {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Process IPC commands (shared logic for both Unix socket and TCP IPC)
+pub fn process_command(cmd: IpcCommand, app: &tauri::AppHandle) -> IpcResponse {
+    match cmd.command.as_str() {
+        "open" => {
+            if let Some(path) = cmd.path {
+                match std::fs::canonicalize(&path) {
+                    Ok(abs_path) => {
+                        let path_str = abs_path.to_string_lossy().to_string();
+
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.unminimize();
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+
+                        match app.emit("open-file", &path_str) {
+                            Ok(_) => IpcResponse {
+                                success: true,
+                                error: None,
+                            },
+                            Err(e) => IpcResponse {
+                                success: false,
+                                error: Some(format!("Failed to emit event: {}", e)),
+                            },
+                        }
+                    }
+                    Err(e) => IpcResponse {
+                        success: false,
+                        error: Some(format!("Invalid path: {}", e)),
+                    },
+                }
+            } else {
+                IpcResponse {
+                    success: false,
+                    error: Some("Missing 'path' field".to_string()),
+                }
+            }
+        }
+        "ping" => IpcResponse {
+            success: true,
+            error: None,
+        },
+        "show" => {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.unminimize();
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+            IpcResponse {
+                success: true,
+                error: None,
+            }
+        }
+        _ => IpcResponse {
+            success: false,
+            error: Some(format!("Unknown command: {}", cmd.command)),
+        },
+    }
+}

--- a/apps/tauri/src-tauri/src/lib.rs
+++ b/apps/tauri/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 
 #[cfg(target_os = "macos")]
 mod cli_installer;
+mod ipc_common;
 #[cfg(unix)]
 mod ipc;
 mod tcp_ipc;

--- a/apps/tauri/src-tauri/src/tcp_ipc.rs
+++ b/apps/tauri/src-tauri/src/tcp_ipc.rs
@@ -1,4 +1,4 @@
-use crate::ipc::{IpcCommand, IpcResponse, process_command};
+use crate::ipc_common::{process_command, IpcCommand, IpcResponse};
 use std::sync::Mutex;
 use tauri::Manager;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};


### PR DESCRIPTION
## Summary

Fixes the Windows build failure in release v0.5.1.

The Windows build was failing with:
```
error[E0432]: unresolved import `crate::ipc`
error: could not compile `arandu` (lib) due to 1 previous error
```

## Root Cause

The `tcp_ipc` module was trying to import types from the `ipc` module, which is Unix-only (`#[cfg(unix)]`). On Windows, this module doesn't exist, causing the import to fail.

## Solution

- Created `ipc_common.rs` module with shared types and logic:
  - `IpcCommand` struct
  - `IpcResponse` struct  
  - `process_command()` function
- This module compiles on **all platforms** (no cfg restrictions)
- Both `ipc.rs` (Unix socket) and `tcp_ipc.rs` (TCP) now import from `ipc_common`
- Removed duplicate code from `ipc.rs`

## Test Plan

- [x] ✅ Verified compilation on macOS: `cargo check`
- [ ] Verify Windows build succeeds in CI
- [ ] Verify Linux builds succeed in CI
- [ ] Verify macOS builds succeed in CI
- [ ] Check that release v0.5.1 completes successfully

## Related

- Release v0.5.1 (Draft): https://github.com/devitools/arandu/releases/tag/v0.5.1
- Failed workflow: https://github.com/devitools/arandu/actions/runs/22324026555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal IPC command handling to consolidate shared functionality into a common module for improved code reusability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->