### PR TITLE
fix(website): remove CNAME from GitHub Pages to enable true fallback

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,4 +28,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website
-          cname: arandu.app  # Remove this line if you want only .github.io domain


### PR DESCRIPTION
## Problem

The previous implementation included `cname: arandu.app` in the GitHub Pages deployment, which causes GitHub Pages to **redirect** `devitools.github.io/arandu/` → `arandu.app`. This defeats the purpose of having a fallback!

If Cloudflare is down or corporate networks block `arandu.app`, the GitHub Pages fallback would also fail due to the redirect.

## Solution

Remove the `cname` parameter from the `peaceiris/actions-gh-pages@v4` action.

**After this fix:**
- ✅ `https://arandu.app` → Cloudflare Pages (primary, no change)
- ✅ `https://devitools.github.io/arandu/` → GitHub Pages (fallback, **no redirect**)

Both URLs work **independently**.

## Test Plan

- [ ] Merge this PR
- [ ] Wait for workflow to deploy
- [ ] Test `https://devitools.github.io/arandu/` loads without redirecting
- [ ] Verify site content is identical on both URLs
- [ ] Confirm fallback works when primary is down

## Technical Details

The `cname` parameter creates a `CNAME` file in the `gh-pages` branch, which instructs GitHub Pages to:
1. Serve the site on the custom domain
2. **Redirect all *.github.io requests** to the custom domain

For a true fallback, we need independent URLs.