### PR TITLE
ci: re-enable Apple notarization for macOS builds

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -108,15 +108,14 @@ jobs:
           Copy-Item shared/*.css apps/tauri/src/ -Force -ErrorAction SilentlyContinue
           Copy-Item shared/*.js apps/tauri/src/ -Force -ErrorAction SilentlyContinue
 
-      # TODO: re-enable notarization when Apple servers are faster
-      # - name: Write Apple API key to disk
-      #   if: matrix.platform == 'macos-latest'
-      #   env:
-      #     APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
-      #   run: |
-      #     if [ -n "$APPLE_API_KEY_CONTENT" ]; then
-      #       echo "$APPLE_API_KEY_CONTENT" > /tmp/apple_api_key.p8
-      #     fi
+      - name: Write Apple API key to disk
+        if: matrix.platform == 'macos-latest'
+        env:
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+        run: |
+          if [ -n "$APPLE_API_KEY_CONTENT" ]; then
+            echo "$APPLE_API_KEY_CONTENT" > /tmp/apple_api_key.p8
+          fi
 
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -126,6 +125,9 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: /tmp/apple_api_key.p8
           CFLAGS: ${{ matrix.target == 'aarch64-apple-darwin' && '-march=armv8.5-a' || '' }}
           CXXFLAGS: ${{ matrix.target == 'aarch64-apple-darwin' && '-march=armv8.5-a' || '' }}
         with:


### PR DESCRIPTION
## Summary

- Re-enabled Apple notarization for macOS builds using App Store Connect API key approach
- Uncommented the step that writes API key to `/tmp/apple_api_key.p8` during macOS builds
- Added required environment variables (`APPLE_API_ISSUER`, `APPLE_API_KEY`, `APPLE_API_KEY_PATH`) to `tauri-action`
- All secrets already configured in repository (added on 2026-02-22)

Notarization was temporarily disabled due to slow Apple server response during initial testing. Now that infrastructure is stable, re-enabling to provide users with properly notarized DMGs that install without security warnings.

## Test plan

- [ ] Verify workflow syntax is correct (GitHub Actions validates on PR)
- [ ] After merge, create a test release to confirm notarization works
- [ ] Monitor build logs for notarization success messages
- [ ] Download DMG and verify it installs without "unidentified developer" warning
- [ ] Check that stapling succeeded (ticket is attached to DMG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS release pipeline configuration to enable proper code signing and distribution through automated build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->