### PR TITLE
feat(cli): add path selection UI for CLI installer

### DIFF
--- a/apps/tauri/src/App.tsx
+++ b/apps/tauri/src/App.tsx
@@ -14,7 +14,7 @@ import { Toaster } from "@/components/ui/sonner";
 
 const { getCurrentWindow } = window.__TAURI__.window;
 const { invoke } = window.__TAURI__.core;
-const { listen } = window.__TAURI__.event;
+const { listen, emit } = window.__TAURI__.event;
 
 const EXPAND_EASING = "cubic-bezier(0.3, 0.0, 0.0, 1)";
 const MINIMIZE_EASING = "cubic-bezier(0.3, 0.0, 0.8, 0.15)";
@@ -143,9 +143,15 @@ function AppContent() {
       openFile();
     });
 
+    const unlistenInstallCli = listen("menu-install-cli", () => {
+      invoke("show_settings_window").catch(console.error);
+      emit("open-settings-tab", "cli").catch(console.error);
+    });
+
     return () => {
       unlistenOpen.then((fn) => fn());
       unlistenMenu.then((fn) => fn());
+      unlistenInstallCli.then((fn) => fn());
     };
   }, [openFile]);
 

--- a/apps/tauri/src/SettingsApp.tsx
+++ b/apps/tauri/src/SettingsApp.tsx
@@ -1,17 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ThemeProvider } from "next-themes";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { WhisperSettings } from "@/components/settings/WhisperSettings";
 import { GeneralSettings } from "@/components/settings/GeneralSettings";
+import { CliInstallSettings } from "@/components/settings/CliInstallSettings";
 import { Toaster } from "@/components/ui/sonner";
 import { useTranslation } from "react-i18next";
-import { Mic, Settings } from "lucide-react";
+import { Mic, Settings, Terminal } from "lucide-react";
 
 const { getCurrentWindow } = window.__TAURI__.window;
+const { listen } = window.__TAURI__.event;
 
 export function SettingsApp() {
   const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState("whisper");
 
   useEffect(() => {
     const currentWindow = getCurrentWindow();
@@ -29,13 +32,22 @@ export function SettingsApp() {
     };
   }, [t]);
 
+  useEffect(() => {
+    const unlisten = listen<string>("open-settings-tab", (event) => {
+      setActiveTab(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="arandu-theme">
       <TooltipProvider>
         <div className="h-screen overflow-hidden bg-background text-foreground flex flex-col">
           <div className="p-6 flex-1 overflow-y-auto">
             <h1 className="text-lg font-semibold mb-4">{t("settings.title")}</h1>
-            <Tabs defaultValue="whisper">
+            <Tabs value={activeTab} onValueChange={setActiveTab}>
               <TabsList className="mb-4">
                 <TabsTrigger value="whisper" className="gap-1.5">
                   <Mic className="h-3.5 w-3.5" />
@@ -45,12 +57,19 @@ export function SettingsApp() {
                   <Settings className="h-3.5 w-3.5" />
                   {t("settings.general")}
                 </TabsTrigger>
+                <TabsTrigger value="cli" className="gap-1.5">
+                  <Terminal className="h-3.5 w-3.5" />
+                  {t("settings.cli")}
+                </TabsTrigger>
               </TabsList>
               <TabsContent value="whisper">
                 <WhisperSettings />
               </TabsContent>
               <TabsContent value="general">
                 <GeneralSettings />
+              </TabsContent>
+              <TabsContent value="cli">
+                <CliInstallSettings />
               </TabsContent>
             </Tabs>
           </div>

--- a/apps/tauri/src/components/settings/CliInstallSettings.tsx
+++ b/apps/tauri/src/components/settings/CliInstallSettings.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle, Circle } from "lucide-react";
+
+const { invoke } = window.__TAURI__.core;
+
+interface CliStatus {
+  installed: boolean;
+  dismissed: boolean;
+}
+
+interface InstallResult {
+  success: boolean;
+  path: string;
+  error: string;
+}
+
+export function CliInstallSettings() {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<CliStatus | null>(null);
+  const [suggestedPaths, setSuggestedPaths] = useState<string[]>([]);
+  const [selectedPath, setSelectedPath] = useState("");
+  const [installing, setInstalling] = useState(false);
+  const [result, setResult] = useState<InstallResult | null>(null);
+
+  useEffect(() => {
+    invoke<CliStatus>("check_cli_status")
+      .then(setStatus)
+      .catch(console.error);
+
+    invoke<string[]>("get_cli_suggested_paths")
+      .then((paths) => {
+        setSuggestedPaths(paths);
+        if (paths.length > 0) setSelectedPath(paths[0]);
+      })
+      .catch(console.error);
+  }, []);
+
+  async function handleInstall() {
+    if (!selectedPath.trim()) return;
+    setInstalling(true);
+    setResult(null);
+    try {
+      const r = await invoke<InstallResult>("install_cli_to_path", { path: selectedPath.trim() });
+      setResult(r);
+      if (r.success) {
+        setStatus((prev) => prev ? { ...prev, installed: true } : { installed: true, dismissed: false });
+      }
+    } catch (e) {
+      setResult({ success: false, path: "", error: String(e) });
+    } finally {
+      setInstalling(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Status */}
+      <div className="flex items-center gap-2">
+        {status?.installed ? (
+          <CheckCircle className="h-4 w-4 text-green-500 shrink-0" />
+        ) : (
+          <Circle className="h-4 w-4 text-muted-foreground shrink-0" />
+        )}
+        <span className="text-sm text-muted-foreground">
+          {status?.installed
+            ? t("settings.cliStatusInstalled")
+            : t("settings.cliStatusNotInstalled")}
+        </span>
+      </div>
+
+      {/* Suggested paths */}
+      {suggestedPaths.length > 0 && (
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">{t("settings.cliSuggestedPaths")}</Label>
+          <div className="flex flex-wrap gap-2">
+            {suggestedPaths.map((p) => (
+              <Badge
+                key={p}
+                variant={selectedPath === p ? "default" : "outline"}
+                className="cursor-pointer font-mono text-xs"
+                onClick={() => { setSelectedPath(p); setResult(null); }}
+              >
+                {p}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Custom path input */}
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">{t("settings.cliCustomPath")}</Label>
+        <Input
+          className="font-mono text-sm"
+          placeholder={t("settings.cliCustomPathPlaceholder")}
+          value={selectedPath}
+          onChange={(e) => { setSelectedPath(e.target.value); setResult(null); }}
+        />
+      </div>
+
+      {/* Install button */}
+      <Button
+        onClick={handleInstall}
+        disabled={installing || !selectedPath.trim()}
+        size="sm"
+      >
+        {installing ? t("settings.cliInstalling") : t("settings.cliInstall")}
+      </Button>
+
+      {/* Feedback */}
+      {result && (
+        <p className={`text-xs ${result.success ? "text-green-600 dark:text-green-400" : "text-destructive"}`}>
+          {result.success
+            ? t("settings.cliSuccess", { path: result.path })
+            : t("settings.cliError", { error: result.error })}
+        </p>
+      )}
+
+      {/* Hint */}
+      <p className="text-xs text-muted-foreground">{t("settings.cliHint")}</p>
+    </div>
+  );
+}

--- a/apps/tauri/src/locales/en.json
+++ b/apps/tauri/src/locales/en.json
@@ -127,6 +127,7 @@
     "title": "Settings",
     "general": "General",
     "whisper": "Voice-to-Text",
+    "cli": "CLI",
     "theme": "Theme",
     "language": "Language",
     "openSettings": "Settings",
@@ -135,7 +136,18 @@
     "copilotPathHint": "Leave blank to use default ($COPILOT_PATH or 'copilot')",
     "ghToken": "GitHub Token",
     "ghTokenPlaceholder": "ghp_... or gho_...",
-    "ghTokenHint": "Required in production builds. Get it with: gh auth token"
+    "ghTokenHint": "Required in production builds. Get it with: gh auth token",
+    "cliTitle": "CLI Installer",
+    "cliStatusInstalled": "Installed",
+    "cliStatusNotInstalled": "Not installed",
+    "cliSuggestedPaths": "Suggested paths",
+    "cliCustomPath": "Custom path",
+    "cliCustomPathPlaceholder": "e.g. /usr/local/bin",
+    "cliInstall": "Install",
+    "cliInstalling": "Installing...",
+    "cliSuccess": "Installed successfully at {{path}}",
+    "cliError": "Installation failed: {{error}}",
+    "cliHint": "User paths (~/…) install without password. System paths may require administrator access."
   },
   "tray": {
     "show": "Show Window",
@@ -146,7 +158,7 @@
   "menu": {
     "arandu": {
       "settings": "Settings\u2026",
-      "installCli": "Install Command Line Tool\u2026"
+      "installCli": "Install CLI\u2026"
     },
     "file": {
       "title": "File",

--- a/apps/tauri/src/locales/pt-BR.json
+++ b/apps/tauri/src/locales/pt-BR.json
@@ -127,6 +127,7 @@
     "title": "Configurações",
     "general": "Geral",
     "whisper": "Voz para Texto",
+    "cli": "CLI",
     "theme": "Tema",
     "language": "Idioma",
     "openSettings": "Configurações",
@@ -135,7 +136,18 @@
     "copilotPathHint": "Deixe em branco para usar o padrão ($COPILOT_PATH ou 'copilot')",
     "ghToken": "GitHub Token",
     "ghTokenPlaceholder": "ghp_... ou gho_...",
-    "ghTokenHint": "Necessário em builds de produção. Obtenha com: gh auth token"
+    "ghTokenHint": "Necessário em builds de produção. Obtenha com: gh auth token",
+    "cliTitle": "Instalador CLI",
+    "cliStatusInstalled": "Instalado",
+    "cliStatusNotInstalled": "Não instalado",
+    "cliSuggestedPaths": "Caminhos sugeridos",
+    "cliCustomPath": "Caminho personalizado",
+    "cliCustomPathPlaceholder": "ex. /usr/local/bin",
+    "cliInstall": "Instalar",
+    "cliInstalling": "Instalando...",
+    "cliSuccess": "Instalado com sucesso em {{path}}",
+    "cliError": "Falha na instalação: {{error}}",
+    "cliHint": "Caminhos de usuário (~/…) instalam sem senha. Caminhos de sistema podem exigir acesso de administrador."
   },
   "tray": {
     "show": "Mostrar Janela",
@@ -146,7 +158,7 @@
   "menu": {
     "arandu": {
       "settings": "Configurações\u2026",
-      "installCli": "Instalar Ferramenta de Linha de Comando\u2026"
+      "installCli": "Instalar CLI\u2026"
     },
     "file": {
       "title": "Arquivo",


### PR DESCRIPTION
## Summary

- Added \`get_suggested_paths()\` and \`install_to_dir()\` to \`cli_installer.rs\`: user paths (\`~/.local/bin\`, \`~/bin\`) install directly without password; system paths (\`/usr/local/bin\`) only prompt for admin via \`osascript\` when explicitly chosen
- Added two new Tauri commands (\`get_cli_suggested_paths\`, \`install_cli_to_path\`) and a dedicated **CLI tab** in the Settings window with \`CliInstallSettings\` component — shows install status, clickable suggested path badges, custom path input, and success/error feedback
- Wired the existing **"Install CLI…"** macOS menu item (previously a no-op) to open the Settings window directly on the CLI tab via \`menu-install-cli\` event + \`open-settings-tab\` event
- Renamed menu label from "Install Command Line Tool…" to "Install CLI…" / "Instalar CLI…"

## Test plan

- [ ] Click **Arandu → Install CLI…** in the macOS menu bar — Settings window should open with the **CLI** tab selected
- [ ] Verify the CLI tab shows install status and the three suggested paths as clickable badges
- [ ] Select \`~/.local/bin\` (or \`~/bin\`) and click **Install** — should install without prompting for a password
- [ ] Select \`/usr/local/bin\` and click **Install** — should prompt for admin password via system dialog
- [ ] Enter a custom path in the input field and install — should use that path
- [ ] After successful install, status indicator should update to "Installed" / "Instalado"
- [ ] Verify error message is shown if installation fails (e.g. invalid path)
- [ ] Switch language to Portuguese and confirm all CLI tab strings are translated
- [ ] Open Settings via **⌘,** — CLI tab should be visible but not auto-selected (stays on last tab)