### PR TITLE
fix(tauri): prevent Vite-only dev crash when __TAURI__ is unavailable

### DIFF
--- a/apps/tauri/src/__tests__/lib/tauri-shim.test.ts
+++ b/apps/tauri/src/__tests__/lib/tauri-shim.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("tauri-shim", () => {
+  let originalTauri: Window["__TAURI__"] | undefined;
+
+  beforeEach(() => {
+    originalTauri = window.__TAURI__;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalTauri) {
+      window.__TAURI__ = originalTauri;
+    } else {
+      delete (window as Partial<Window>).__TAURI__;
+    }
+  });
+
+  it("creates a safe fallback when __TAURI__ is missing", async () => {
+    delete (window as Partial<Window>).__TAURI__;
+
+    await import("@/lib/tauri-shim");
+
+    expect(window.__TAURI__).toBeDefined();
+    expect(await window.__TAURI__.core.invoke("workspace_list")).toEqual([]);
+    expect(await window.__TAURI__.core.invoke("get_home_dir")).toBeNull();
+    expect(await window.__TAURI__.dialog.open()).toBeNull();
+  });
+
+  it("does not override an existing __TAURI__ object", async () => {
+    const existing = {
+      core: { invoke: vi.fn().mockResolvedValue("existing") },
+      window: { getCurrentWindow: vi.fn() },
+      dialog: { open: vi.fn() },
+      event: {
+        emit: vi.fn(),
+        listen: vi.fn(),
+      },
+    } as unknown as Window["__TAURI__"];
+
+    window.__TAURI__ = existing;
+
+    await import("@/lib/tauri-shim");
+
+    expect(window.__TAURI__).toBe(existing);
+    expect(await window.__TAURI__.core.invoke("workspace_list")).toBe("existing");
+  });
+});

--- a/apps/tauri/src/lib/tauri-shim.ts
+++ b/apps/tauri/src/lib/tauri-shim.ts
@@ -14,7 +14,11 @@ function getBrowserInvokeFallback(command: string): InvokeResult {
     case "workspace_list":
     case "session_list":
     case "load_history":
+    case "list_models":
+    case "list_audio_devices":
       return [];
+    case "get_whisper_settings":
+      return {};
     case "plan_path":
     case "get_initial_file":
     case "get_home_dir":

--- a/apps/tauri/src/lib/tauri-shim.ts
+++ b/apps/tauri/src/lib/tauri-shim.ts
@@ -1,0 +1,58 @@
+type InvokeResult =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Record<string, unknown>
+  | Array<unknown>;
+
+const noopAsync = async () => {};
+
+function getBrowserInvokeFallback(command: string): InvokeResult {
+  switch (command) {
+    case "workspace_list":
+    case "session_list":
+    case "load_history":
+      return [];
+    case "plan_path":
+    case "get_initial_file":
+    case "get_home_dir":
+      return null;
+    case "render_markdown":
+      return "";
+    case "hash_file":
+      return "";
+    case "count_unresolved_comments":
+      return 0;
+    default:
+      return null;
+  }
+}
+
+if (typeof window !== "undefined" && !window.__TAURI__) {
+  const browserTauriShim = {
+    core: {
+      invoke: async <T = unknown>(command: string) =>
+        getBrowserInvokeFallback(command) as T,
+    },
+    window: {
+      getCurrentWindow: () =>
+        ({
+          label: "main",
+          hide: noopAsync,
+          show: noopAsync,
+          setFocus: noopAsync,
+        }) as unknown,
+    },
+    dialog: {
+      open: async () => null,
+    },
+    event: {
+      listen: async () => () => {},
+      emit: noopAsync,
+    },
+  } as Window["__TAURI__"];
+
+  window.__TAURI__ = browserTauriShim;
+}

--- a/apps/tauri/src/main.tsx
+++ b/apps/tauri/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "@/lib/tauri-shim";
 import "@/lib/i18n";
 import App from "./App";
 import "./index.css";

--- a/apps/tauri/src/settings-main.tsx
+++ b/apps/tauri/src/settings-main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "@/lib/tauri-shim";
 import "@/lib/i18n";
 import { SettingsApp } from "./SettingsApp";
 import "./index.css";

--- a/apps/tauri/src/whisper-main.tsx
+++ b/apps/tauri/src/whisper-main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "@/lib/tauri-shim";
 import "@/lib/i18n";
 import { WhisperApp } from "./WhisperApp";
 import "./index.css";


### PR DESCRIPTION
## What this fixes
Running `npm run dev` (Vite-only) crashed at startup with:

`Uncaught TypeError: Cannot read properties of undefined (reading 'core')`

**Root cause:** modules accessed `window.__TAURI__` at import time, but Vite/browser mode has no Tauri runtime injected.

## What changed
- Added a browser-safe shim:
- Loaded shim before app bootstrap in all entrypoints
- Added regression tests

## Behavior
- In browser/Vite mode: no crash, Tauri calls fall back to safe no-ops/defaults.
- In Tauri mode: existing `window.__TAURI__` is preserved (shim does not override).

## How to validate
```bash
cd apps/tauri
npm run dev
npm test -- tauri-shim.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser-compatible Tauri shim that provides safe fallbacks for core integrations in non-Tauri environments.

* **Chores**
  * Initialized the shim in the app frontend entry points to ensure graceful behavior across pages.

* **Tests**
  * Added tests verifying fallback behavior and that existing Tauri implementations are preserved when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->