### PR TITLE
docs: add deprecation notice for macOS native app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Arandu is a Markdown viewer and AI-assisted workspace application built with **T
 - CLI installer for macOS
 - Unix domain socket + TCP IPC for external process communication
 
-**IMPORTANT:** The macOS native version (`apps/macos/`) is DEPRECATED. All development happens in the Tauri version (`apps/tauri/`).
+**IMPORTANT:** The macOS native version (`apps/macos-deprecated/`) is DEPRECATED. All development happens in the Tauri version (`apps/tauri/`).
 
 ## Build Commands
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ An intelligent development companion — Markdown viewer, AI workspace, and plan
 ![Linux](https://img.shields.io/badge/Linux-x86__64-orange)
 ![Windows](https://img.shields.io/badge/Windows-x86__64-green)
 
+## Applications
+
+### Tauri (Primary) ✅
+
+Cross-platform desktop app supporting macOS, Linux, and Windows.
+
+- **Location**: [`apps/tauri/`](apps/tauri/)
+- **Status**: Active development
+- **Stack**: Rust + React + TypeScript + Vite + TailwindCSS
+
+### macOS Native (Deprecated) ⚠️
+
+Legacy macOS-only app built with Swift + AppKit + WebKit.
+
+- **Location**: [`apps/macos-deprecated/`](apps/macos-deprecated/)
+- **Status**: **Discontinued** as of February 2025
+- **Replacement**: Use the Tauri app instead
+- **Details**: See [`apps/macos-deprecated/DEPRECATED.md`](apps/macos-deprecated/DEPRECATED.md)
+
 ## Features
 
 ### Document Viewing
@@ -239,7 +258,7 @@ Key libraries:
 For full architecture documentation, command reference, and codebase conventions, see [CLAUDE.md](./CLAUDE.md).
 
 Key points:
-- The macOS native app (`apps/macos/`) is **deprecated** — use the Tauri version only
+- The macOS native app (`apps/macos-deprecated/`) is **deprecated** — use the Tauri version only
 - Frontend is React + TypeScript — no vanilla JS, Vite handles the build
 - New Tauri commands: define in Rust → register in `invoke_handler` → add permissions to `capabilities/default.json`
 - UI components are from shadcn/ui — add new ones with `npx shadcn@latest add <component>`

--- a/apps/macos-deprecated/DEPRECATED.md
+++ b/apps/macos-deprecated/DEPRECATED.md
@@ -1,0 +1,34 @@
+# ⚠️ DEPRECATED
+
+This macOS native app (Swift + AppKit + WebKit) has been **discontinued** as of February 2025.
+
+## Why?
+
+The project now focuses exclusively on the **Tauri cross-platform app** (`apps/tauri/`), which provides:
+
+- Cross-platform support (macOS, Linux, Windows)
+- Unified codebase and maintenance
+- Better plugin ecosystem
+- All features from the native app + new capabilities (ACP integration, plan workflow, voice-to-text, and more)
+
+## Migration
+
+If you're using the macOS native app, please switch to the Tauri version:
+
+```bash
+cd apps/tauri
+npm install
+npx tauri build
+```
+
+Or install via Homebrew:
+
+```bash
+brew install --cask devitools/arandu/arandu
+```
+
+## Archive
+
+This code is kept for historical reference and learning purposes. It will not receive updates or bug fixes.
+
+**Last maintained**: v0.2.0 (February 2025)

--- a/apps/macos-deprecated/README.md
+++ b/apps/macos-deprecated/README.md
@@ -1,0 +1,7 @@
+# ⚠️ DEPRECATED — macOS Native App
+
+> **This app has been discontinued. Use [apps/tauri](../tauri/) instead.**
+
+This directory contains the legacy macOS-only implementation (Swift + AppKit + WebKit) and is kept for historical purposes only.
+
+For the full deprecation notice and migration instructions, see [DEPRECATED.md](./DEPRECATED.md).

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -7,7 +7,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 echo "Setting version to $VERSION across all configs..."
 
 # 1. macOS Info.plist
-PLIST="$ROOT/apps/macos/Sources/Arandu/Info.plist"
+PLIST="$ROOT/apps/macos-deprecated/Sources/Arandu/Info.plist"
 if [ -f "$PLIST" ]; then
   /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$PLIST"
   /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $VERSION" "$PLIST"


### PR DESCRIPTION
## Summary

Add deprecation documentation for the macOS native app (`apps/macos-deprecated/`) to prevent contributor confusion and clarify that Tauri is the sole active target.

- Add `DEPRECATED.md` to `apps/macos-deprecated/` with full rationale, migration instructions, and archive notice
- Add `README.md` to `apps/macos-deprecated/` with a concise deprecation banner pointing to the Tauri app
- Add a prominent **Applications** section to the root `README.md` distinguishing the active Tauri app (✅) from the deprecated macOS native app (⚠️)
- Fix stale `apps/macos/` path references in `README.md`, `CLAUDE.md`, and `scripts/set-version.sh`

## Context

Addresses [#5](https://github.com/devitools/arandu/issues/5). The directory was already renamed from `apps/macos` to `apps/macos-deprecated` (Option 1), but there was no documentation explaining the deprecation. This PR implements the recommended Options 2 + 3 + 4 from the issue.

## Changes

| File | Change |
|------|--------|
| `apps/macos-deprecated/DEPRECATED.md` | **New** — Full deprecation notice with rationale, migration path, and archive status |
| `apps/macos-deprecated/README.md` | **New** — Concise banner redirecting to Tauri app |
| `README.md` | **Updated** — Added Applications section near the top; fixed stale path in Contributing |
| `CLAUDE.md` | **Updated** — Fixed `apps/macos/` → `apps/macos-deprecated/` reference |
| `scripts/set-version.sh` | **Updated** — Fixed Info.plist path to match renamed directory |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Deprecated the macOS native application, relocating the codebase to `apps/macos-deprecated/` and marking it discontinued as of February 2025.
  * Added comprehensive deprecation notices with clear migration guidance, directing users to adopt the cross-platform Tauri application for continued support.
  * Updated repository documentation to clarify that all future development is exclusively focused on the Tauri application under `apps/tauri/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->